### PR TITLE
Updated to Gnome 43

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ This extension uses "pkexec" since sudo permissions are needed to change the thr
 
 ![Screenshot](screenshot.png)
 
-Tested on Fedora Silverblue 35 (gnome-shell 3.41) on an Asus Vivobook.
+Tested on Fedora 37 (gnome-shell 43) on Asus Zenbook UX433F.

--- a/batterythreshold@francku.gitlab.com/metadata.json
+++ b/batterythreshold@francku.gitlab.com/metadata.json
@@ -4,6 +4,6 @@
   "uuid": "batterythreshold@francku.gitlab.com",
   "version": 2,
   "shell-version": [
-    "41", "42"
+    "41", "42", "43"
   ]
 }


### PR DESCRIPTION
updated metadata.json to support gnome 43. Tested on fedora 37, GNOME 43.